### PR TITLE
add shuffleArray function and test

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -42,6 +42,31 @@ function nOfFibonacci(x) {
   return (!n || n < 1) ? -1 : (n < 3 ? 1 : (nOfFibonacci(n-1) + nOfFibonacci(n-2)));
 }
 
+// shuffle an array using the Fisher-Yates algorithm
+// retyped from https://stackoverflow.com/a/6274398
+function shuffleArray(array) {
+  // first, clone the array
+  const new_array = array.slice(0);
+  // we start counting from the end
+  let currentIndex = array.length;
+
+  // while we still have elements to shuffle
+  while ( currentIndex > 0 ) {
+    // pick a random element (from the remaining ones)
+    let randomIndex = Math.floor( Math.random() * currentIndex );
+    // move the index
+    currentIndex -= 1;
+    // we hold the value we're going to replace
+    let temporaryValue = new_array[currentIndex];
+    // replace the last element with the random one
+    new_array[currentIndex] = new_array[randomIndex];
+    // and put the value held in the random element's position
+    new_array[randomIndex] = temporaryValue;
+  }
+
+  return new_array;
+}
+
 module.exports = {
   sum: sum,
   sub: sub,
@@ -52,5 +77,6 @@ module.exports = {
   answer: answer,
   anomalyCode: anomalyCode,
   power: power,
-  nOfFibonacci: nOfFibonacci
+  nOfFibonacci: nOfFibonacci,
+  shuffleArray: shuffleArray
 }

--- a/sketch.test.js
+++ b/sketch.test.js
@@ -1,4 +1,4 @@
-const { sum, sub, prod, digital_root, sum42, sayHelloTo, anomalyCode, power, nOfFibonacci } = require('./sketch');
+const { sum, sub, prod, digital_root, sum42, sayHelloTo, anomalyCode, power, nOfFibonacci, shuffleArray } = require('./sketch');
 const fs = require("fs");
 const path = require("path");
 const fetch = require("node-fetch");
@@ -128,4 +128,32 @@ it('tests url avaliability in README.md', async () => {
   let [testCount, testFunc] = testUrlInMarkdown("README.md");
   jest.setTimeout(testCount * 5000);
   return await testFunc();
+});
+
+test('shuffleArray function exists', () => {
+  expect(shuffleArray).toBeDefined();
+});
+
+test('randomly created and shuffled arrays should be different from the original', () => {
+  const masterArray = [];
+  const resultsArray = [];
+  for ( let i=0; i<10; i++ ){
+    let array = [];
+    // random length between 10 and 30
+    let len = Math.floor( Math.random()*20 + 10 );
+    // add random values between 10 and 110
+    for ( let j=0; j<len; j++ ) {
+      array[j] = Math.floor( Math.random()*100 + 10 );
+    }
+    masterArray.push( array );
+    let shuffled = shuffleArray(array);
+    resultsArray.push( shuffled );
+
+    // shuffle the array and expect it:
+    // - have same length
+    expect( shuffled.length ).toBe( array.length );
+  }
+
+  // shuffled arrays must have at least one that is different from the original
+  expect( resultsArray ).not.toBe( masterArray );
 });


### PR DESCRIPTION
add Fisher-Yates array shuffling function plus a test for it.
the test runs 10 times and checks for:
- the length of each array not to be altered
- the group of 10 shuffled arrays should not be equal to the original ones

The reason to run it 10 times is because it is possible that the function returns the same original array, but running it 10 times makes it significantly unlikely for it to happen